### PR TITLE
ADD: Helius getTransfersByAddress and getTransactionsForAddress endpoints

### DIFF
--- a/docs/interactions/helius/index.md
+++ b/docs/interactions/helius/index.md
@@ -138,3 +138,5 @@ The documentation follows the library's structure by providing all the technical
 | getSignaturesForAsset | `POST` | [`post_get_signatures_for_asset`](../helius/interaction.md#cyhole.helius.Helius._post_get_signatures_for_asset) | `0.3.0` | - |
 | getNftEditions | `POST` | [`post_get_nft_editions`](../helius/interaction.md#cyhole.helius.Helius._post_get_nft_editions) | `0.3.0` | - |
 | getTokenAccounts | `POST` | [`post_get_token_accounts`](../helius/interaction.md#cyhole.helius.Helius._post_get_token_accounts) | `0.3.0` | - |
+| getTransfersByAddress | `POST` | [`post_get_transfers_by_address`](../helius/interaction.md#cyhole.helius.Helius._post_get_transfers_by_address) | `0.3.0` | - |
+| getTransactionsForAddress | `POST` | [`post_get_transactions_for_address`](../helius/interaction.md#cyhole.helius.Helius._post_get_transactions_for_address) | `0.3.0` | - |

--- a/src/cyhole/helius/client.py
+++ b/src/cyhole/helius/client.py
@@ -11,6 +11,8 @@ from ..helius.schema import (
     PostGetAssetsByAuthorityBody,
     PostSearchAssetsBody,
     PostGetTokenAccountsBody,
+    PostGetTransfersByAddressBody,
+    PostGetTransactionsForAddressBody,
     PostGetAssetResponse,
     PostGetAssetBatchResponse,
     PostGetAssetProofResponse,
@@ -23,6 +25,8 @@ from ..helius.schema import (
     PostGetSignaturesForAssetResponse,
     PostGetNftEditionsResponse,
     PostGetTokenAccountsResponse,
+    PostGetTransfersByAddressResponse,
+    PostGetTransactionsForAddressResponse,
 )
 
 if TYPE_CHECKING:
@@ -120,6 +124,20 @@ class HeliusClient(APIClient):
         """
         return self._interaction._post_get_token_accounts(True, body)
 
+    def post_get_transfers_by_address(self, address: str, body: PostGetTransfersByAddressBody | None = None) -> PostGetTransfersByAddressResponse:
+        """
+        Call the Helius POST **[getTransfersByAddress](https://www.helius.dev/docs/rpc/gettransfersbyaddress)** RPC API endpoint for synchronous logic.
+        All the API endpoint details are available on [`Helius._post_get_transfers_by_address`][cyhole.helius.interaction.Helius._post_get_transfers_by_address].
+        """
+        return self._interaction._post_get_transfers_by_address(True, address, body)
+
+    def post_get_transactions_for_address(self, address: str, body: PostGetTransactionsForAddressBody | None = None) -> PostGetTransactionsForAddressResponse:
+        """
+        Call the Helius POST **[getTransactionsForAddress](https://www.helius.dev/docs/rpc/gettransactionsforaddress)** RPC API endpoint for synchronous logic.
+        All the API endpoint details are available on [`Helius._post_get_transactions_for_address`][cyhole.helius.interaction.Helius._post_get_transactions_for_address].
+        """
+        return self._interaction._post_get_transactions_for_address(True, address, body)
+
 
 class HeliusAsyncClient(AsyncAPIClient):
     """Client for asynchronous API calls for `Helius` interaction."""
@@ -211,3 +229,17 @@ class HeliusAsyncClient(AsyncAPIClient):
         All the API endpoint details are available on [`Helius._post_get_token_accounts`][cyhole.helius.interaction.Helius._post_get_token_accounts].
         """
         return await self._interaction._post_get_token_accounts(False, body)
+
+    async def post_get_transfers_by_address(self, address: str, body: PostGetTransfersByAddressBody | None = None) -> PostGetTransfersByAddressResponse:
+        """
+        Call the Helius POST **[getTransfersByAddress](https://www.helius.dev/docs/rpc/gettransfersbyaddress)** RPC API endpoint for asynchronous logic.
+        All the API endpoint details are available on [`Helius._post_get_transfers_by_address`][cyhole.helius.interaction.Helius._post_get_transfers_by_address].
+        """
+        return await self._interaction._post_get_transfers_by_address(False, address, body)
+
+    async def post_get_transactions_for_address(self, address: str, body: PostGetTransactionsForAddressBody | None = None) -> PostGetTransactionsForAddressResponse:
+        """
+        Call the Helius POST **[getTransactionsForAddress](https://www.helius.dev/docs/rpc/gettransactionsforaddress)** RPC API endpoint for asynchronous logic.
+        All the API endpoint details are available on [`Helius._post_get_transactions_for_address`][cyhole.helius.interaction.Helius._post_get_transactions_for_address].
+        """
+        return await self._interaction._post_get_transactions_for_address(False, address, body)

--- a/src/cyhole/helius/interaction.py
+++ b/src/cyhole/helius/interaction.py
@@ -12,6 +12,8 @@ from ..helius.schema import (
     PostGetAssetsByAuthorityBody,
     PostSearchAssetsBody,
     PostGetTokenAccountsBody,
+    PostGetTransfersByAddressBody,
+    PostGetTransactionsForAddressBody,
     PostGetAssetResponse,
     PostGetAssetBatchResponse,
     PostGetAssetProofResponse,
@@ -24,6 +26,8 @@ from ..helius.schema import (
     PostGetSignaturesForAssetResponse,
     PostGetNftEditionsResponse,
     PostGetTokenAccountsResponse,
+    PostGetTransfersByAddressResponse,
+    PostGetTransactionsForAddressResponse,
 )
 
 
@@ -440,3 +444,103 @@ class Helius(Interaction):
             "params": body.model_dump(exclude_none = True),
         }
         return self.api_return_model(sync, RequestType.POST.value, self.url_api, PostGetTokenAccountsResponse, json = rpc_body)
+
+    # ─── getTransfersByAddress ────────────────────────────────────────────────
+
+    @overload
+    def _post_get_transfers_by_address(self, sync: Literal[True], address: str, body: PostGetTransfersByAddressBody | None = None) -> PostGetTransfersByAddressResponse: ...
+    @overload
+    def _post_get_transfers_by_address(self, sync: Literal[False], address: str, body: PostGetTransfersByAddressBody | None = None) -> Coroutine[None, None, PostGetTransfersByAddressResponse]: ...
+    def _post_get_transfers_by_address(self, sync: bool, address: str, body: PostGetTransfersByAddressBody | None = None) -> PostGetTransfersByAddressResponse | Coroutine[None, None, PostGetTransfersByAddressResponse]:
+        """
+        This function refers to the **getTransfersByAddress** Helius RPC endpoint.
+
+        Returns parsed, human-readable token and native SOL transfer records for a
+        wallet owner address, suitable for ledgers, payment tracking, and balance
+        reconciliation. Results can be narrowed by counterparty, direction, mint,
+        amount/time/slot ranges and paginated via `pagination_token`.
+
+        The endpoint is a Helius-exclusive feature (not part of standard Solana RPC),
+        requires a Developer plan or higher, costs 10 credits per request, and
+        returns at most the most recent 1 year of transfer history. Failed
+        transactions and hidden SOL balance-change movements are not included.
+
+        Parameters:
+            sync: if `True` run synchronously, else return a coroutine.
+            address: base58-encoded wallet **owner** address to query. Must be the
+                owner wallet, not an associated token account (ATA).
+            body: optional configuration object — see
+                [`PostGetTransfersByAddressBody`][cyhole.helius.schema.PostGetTransfersByAddressBody].
+                All fields are optional. Use it to filter by counterparty, direction
+                ([`HeliusTransferDirection`][cyhole.helius.param.HeliusTransferDirection]),
+                mint, SOL/WSOL mode ([`HeliusSolMode`][cyhole.helius.param.HeliusSolMode]),
+                numeric ranges, commitment ([`HeliusCommitment`][cyhole.helius.param.HeliusCommitment]),
+                ordering ([`HeliusSortOrder`][cyhole.helius.param.HeliusSortOrder]),
+                and pagination (`limit`, `pagination_token`).
+
+        Returns:
+            PostGetTransfersByAddressResponse: paginated transfer rows wrapped in a
+                JSON-RPC 2.0 envelope. Access the rows via `response.result.data`
+                and the next-page cursor via `response.result.pagination_token`
+                (`None` when there are no more pages).
+        """
+        params: list = [address]
+        if body is not None:
+            params.append(body.model_dump(by_alias = True, exclude_none = True))
+        rpc_body = {"jsonrpc": "2.0", "id": "cyhole", "method": "getTransfersByAddress", "params": params}
+        return self.api_return_model(sync, RequestType.POST.value, self.url_api, PostGetTransfersByAddressResponse, json = rpc_body)
+
+    # ─── getTransactionsForAddress ────────────────────────────────────────────
+
+    @overload
+    def _post_get_transactions_for_address(self, sync: Literal[True], address: str, body: PostGetTransactionsForAddressBody | None = None) -> PostGetTransactionsForAddressResponse: ...
+    @overload
+    def _post_get_transactions_for_address(self, sync: Literal[False], address: str, body: PostGetTransactionsForAddressBody | None = None) -> Coroutine[None, None, PostGetTransactionsForAddressResponse]: ...
+    def _post_get_transactions_for_address(self, sync: bool, address: str, body: PostGetTransactionsForAddressBody | None = None) -> PostGetTransactionsForAddressResponse | Coroutine[None, None, PostGetTransactionsForAddressResponse]:
+        """
+        This function refers to the **getTransactionsForAddress** Helius RPC endpoint.
+
+        Returns the transaction history for any Solana account with advanced
+        filtering (time, slot, signature, success/failure status, token-account
+        inclusion), bidirectional sorting (`asc` / `desc`), and cursor-based
+        pagination. Unlike `getSignaturesForAddress`, this endpoint can optionally
+        return the **full transaction payload** in a single call and can include
+        activity on token accounts owned by the queried wallet via
+        `filters.token_accounts`.
+
+        The endpoint is a Helius-exclusive feature (not part of standard Solana RPC),
+        requires a Developer plan or higher, costs 50 credits per request and
+        returns up to 100 full transactions or 1,000 signatures per page. The
+        `token_accounts` filter does not see transactions prior to December 2022;
+        devnet retention is limited to 2 weeks while mainnet retention is unlimited.
+
+        Parameters:
+            sync: if `True` run synchronously, else return a coroutine.
+            address: base58-encoded account address to query (wallet, program, mint,
+                pool, or token account).
+            body: optional configuration object — see
+                [`PostGetTransactionsForAddressBody`][cyhole.helius.schema.PostGetTransactionsForAddressBody].
+                All fields are optional. Use it to choose detail level
+                ([`HeliusTransactionDetails`][cyhole.helius.param.HeliusTransactionDetails]),
+                sort order ([`HeliusSortOrder`][cyhole.helius.param.HeliusSortOrder]),
+                commitment ([`HeliusCommitment`][cyhole.helius.param.HeliusCommitment]),
+                encoding ([`HeliusEncoding`][cyhole.helius.param.HeliusEncoding]),
+                and filters such as status
+                ([`HeliusTransactionStatus`][cyhole.helius.param.HeliusTransactionStatus])
+                and token-account inclusion
+                ([`HeliusTokenAccountFilter`][cyhole.helius.param.HeliusTokenAccountFilter]).
+
+        Returns:
+            PostGetTransactionsForAddressResponse: paginated transaction list wrapped
+                in a JSON-RPC 2.0 envelope. Access the rows via `response.result.data`
+                and the next-page cursor via `response.result.pagination_token`
+                (`None` when there are no more pages). Each
+                [`TransactionForAddressItem`][cyhole.helius.schema.TransactionForAddressItem]
+                exposes signature-mode or full-mode fields depending on the
+                `transaction_details` parameter.
+        """
+        params: list = [address]
+        if body is not None:
+            params.append(body.model_dump(by_alias = True, exclude_none = True))
+        rpc_body = {"jsonrpc": "2.0", "id": "cyhole", "method": "getTransactionsForAddress", "params": params}
+        return self.api_return_model(sync, RequestType.POST.value, self.url_api, PostGetTransactionsForAddressResponse, json = rpc_body)

--- a/src/cyhole/helius/param.py
+++ b/src/cyhole/helius/param.py
@@ -45,3 +45,123 @@ class HeliusTokenType(CyholeParam):
     REGULAR_NFT = "regularNft"
     COMPRESSED_NFT = "compressedNft"
     ALL = "all"
+
+
+class HeliusTransferDirection(CyholeParam):
+    """
+    Direction filter for the `getTransfersByAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransfersByAddressBody`][cyhole.helius.schema.PostGetTransfersByAddressBody]
+    as the `direction` parameter.
+    """
+    IN = "in"
+    """Transfers received by the queried address."""
+    OUT = "out"
+    """Transfers sent by the queried address."""
+    ANY = "any"
+    """Both incoming and outgoing transfers (API default)."""
+
+
+class HeliusSolMode(CyholeParam):
+    """
+    SOL/WSOL representation mode for the `getTransfersByAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransfersByAddressBody`][cyhole.helius.schema.PostGetTransfersByAddressBody]
+    as the `sol_mode` parameter.
+    """
+    MERGED = "merged"
+    """Treat WSOL as native SOL: WSOL mints are rewritten to the native SOL mint and wrap/unwrap lifecycle rows are excluded (API default)."""
+    SEPARATE = "separate"
+    """Keep WSOL as a distinct SPL mint and include wrap/unwrap lifecycle rows."""
+
+
+class HeliusCommitment(CyholeParam):
+    """
+    Commitment level for the `getTransfersByAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransfersByAddressBody`][cyhole.helius.schema.PostGetTransfersByAddressBody]
+    as the `commitment` parameter.
+    """
+    FINALIZED = "finalized"
+    """Only include transfers from finalized blocks (API default)."""
+    CONFIRMED = "confirmed"
+    """Include transfers from confirmed (not yet finalized) blocks."""
+
+
+class HeliusSortOrder(CyholeParam):
+    """
+    Result ordering for the `getTransfersByAddress` and `getTransactionsForAddress`
+    RPC endpoints.
+
+    Pass the `.value` to
+    [`PostGetTransfersByAddressBody`][cyhole.helius.schema.PostGetTransfersByAddressBody]
+    or [`PostGetTransactionsForAddressBody`][cyhole.helius.schema.PostGetTransactionsForAddressBody]
+    as the `sort_order` parameter.
+    """
+    DESC = "desc"
+    """Newest first (API default)."""
+    ASC = "asc"
+    """Oldest first."""
+
+
+class HeliusTransactionDetails(CyholeParam):
+    """
+    Transaction detail level for the `getTransactionsForAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransactionsForAddressBody`][cyhole.helius.schema.PostGetTransactionsForAddressBody]
+    as the `transaction_details` parameter.
+    """
+    SIGNATURES = "signatures"
+    """Return only signature-level info — faster, default mode (limit up to 1,000)."""
+    FULL = "full"
+    """Return the complete transaction payload — eliminates the need for follow-up `getTransaction` calls (limit must be `<= 100`)."""
+
+
+class HeliusTransactionStatus(CyholeParam):
+    """
+    Transaction status filter for the `getTransactionsForAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransactionsForAddressFilters`][cyhole.helius.schema.PostGetTransactionsForAddressFilters]
+    as the `status` parameter.
+    """
+    SUCCEEDED = "succeeded"
+    """Only successful transactions."""
+    FAILED = "failed"
+    """Only failed transactions."""
+    ANY = "any"
+    """Both successful and failed transactions (API default)."""
+
+
+class HeliusTokenAccountFilter(CyholeParam):
+    """
+    Token-account inclusion filter for the `getTransactionsForAddress` RPC endpoint.
+
+    Pass the `.value` to [`PostGetTransactionsForAddressFilters`][cyhole.helius.schema.PostGetTransactionsForAddressFilters]
+    as the `token_accounts` parameter.
+
+    Not supported for transactions older than December 2022.
+    """
+    NONE = "none"
+    """Only return transactions that directly reference the wallet address (API default)."""
+    BALANCE_CHANGED = "balanceChanged"
+    """Include transactions that reference the address or modify the balance of a token account it owns (recommended)."""
+    ALL = "all"
+    """Include any transaction that references the address or any token account it owns."""
+
+
+class HeliusEncoding(CyholeParam):
+    """
+    Encoding format for the transaction payload, used by the
+    `getTransactionsForAddress` RPC endpoint when `transaction_details = "full"`.
+
+    Pass the `.value` to [`PostGetTransactionsForAddressBody`][cyhole.helius.schema.PostGetTransactionsForAddressBody]
+    as the `encoding` parameter.
+    """
+    JSON = "json"
+    """Default JSON encoding (raw account keys and instruction data)."""
+    JSON_PARSED = "jsonParsed"
+    """JSON encoding with parsed instructions for known programs (SPL Token, System, etc.)."""
+    BASE64 = "base64"
+    """Base64 encoding of the raw transaction bytes."""
+    BASE58 = "base58"
+    """Base58 encoding of the raw transaction bytes."""

--- a/src/cyhole/helius/schema.py
+++ b/src/cyhole/helius/schema.py
@@ -427,6 +427,190 @@ class PostGetTokenAccountsBody(BaseModel):
     limit: int | None = None
 
 
+# ─── getTransfersByAddress schemas ─────────────────────────────────────────────
+
+class HeliusComparisonFilter(BaseModel):
+    """
+    Numeric range filter used by
+    [`PostGetTransfersByAddressFilters`][cyhole.helius.schema.PostGetTransfersByAddressFilters]
+    and [`PostGetTransactionsForAddressFilters`][cyhole.helius.schema.PostGetTransactionsForAddressFilters].
+
+    All operators are optional and can be combined freely; an omitted bound
+    means the value is unconstrained on that side.
+
+    Attributes:
+        gt: greater than this value (exclusive). `None` if no lower bound.
+        gte: greater than or equal to this value (inclusive). `None` if no lower bound.
+        lt: less than this value (exclusive). `None` if no upper bound.
+        lte: less than or equal to this value (inclusive). `None` if no upper bound.
+        eq: exact match. `None` when no equality match is required. Only honored by the
+            `blockTime` filter of the `getTransactionsForAddress` RPC endpoint.
+    """
+    gt: int | None = None
+    gte: int | None = None
+    lt: int | None = None
+    lte: int | None = None
+    eq: int | None = None
+
+
+class HeliusSignatureComparisonFilter(BaseModel):
+    """
+    Lexicographic range filter on a transaction signature, used by the `signature`
+    filter of [`PostGetTransactionsForAddressFilters`][cyhole.helius.schema.PostGetTransactionsForAddressFilters].
+
+    Values are base58-encoded signature strings; comparison is performed
+    lexicographically by the API.
+
+    Attributes:
+        gt: greater than this signature (exclusive). `None` if no lower bound.
+        gte: greater than or equal to this signature (inclusive). `None` if no lower bound.
+        lt: less than this signature (exclusive). `None` if no upper bound.
+        lte: less than or equal to this signature (inclusive). `None` if no upper bound.
+    """
+    gt: str | None = None
+    gte: str | None = None
+    lt: str | None = None
+    lte: str | None = None
+
+
+class PostGetTransfersByAddressFilters(BaseModel):
+    """
+    Optional numeric filters for the `getTransfersByAddress` RPC method.
+
+    Attributes:
+        amount: filter by raw transfer amount (not UI amount). `None` means no constraint on amount.
+        block_time: filter by block timestamp in Unix seconds. `None` means no time bound.
+        slot: filter by slot number. `None` means no slot bound.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    amount: HeliusComparisonFilter | None = None
+    block_time: HeliusComparisonFilter | None = Field(default = None, alias = "blockTime")
+    slot: HeliusComparisonFilter | None = None
+
+
+class PostGetTransfersByAddressBody(BaseModel):
+    """
+    Request body (the `config` object) for the `getTransfersByAddress` RPC method.
+
+    The owner `address` is passed as the first positional parameter of the JSON-RPC
+    call and is therefore handled separately by the
+    [`Helius._post_get_transfers_by_address`][cyhole.helius.interaction.Helius._post_get_transfers_by_address]
+    method; every field of this body model is optional.
+
+    Attributes:
+        with_address: counterparty address — return only transfers to or from this wallet.
+            `None` means no counterparty filter.
+        direction: transfer direction relative to the queried address. Accepts the
+            values of [`HeliusTransferDirection`][cyhole.helius.param.HeliusTransferDirection]
+            (`"in"`, `"out"`, `"any"`). API default: `"any"`.
+        mint: token mint address to filter by. Use `So11111111111111111111111111111111111111111`
+            for native SOL and `So11111111111111111111111111111111111111112` for WSOL.
+            `None` means no mint filter.
+        sol_mode: how native SOL and WSOL are represented. Accepts the values of
+            [`HeliusSolMode`][cyhole.helius.param.HeliusSolMode] (`"merged"`, `"separate"`).
+            API default: `"merged"` (WSOL is collapsed into native SOL, wrap/unwrap
+            lifecycle rows are excluded).
+        filters: optional numeric filters for amount, block time, and slot.
+        limit: maximum number of transfers returned per page (range `1`–`100`).
+            API default: `100`.
+        pagination_token: cursor from the previous response — pass the value
+            received in `result.pagination_token` to fetch the next page.
+        commitment: data commitment level. Accepts the values of
+            [`HeliusCommitment`][cyhole.helius.param.HeliusCommitment] (`"finalized"`,
+            `"confirmed"`). API default: `"finalized"`.
+        sort_order: result ordering. Accepts the values of
+            [`HeliusSortOrder`][cyhole.helius.param.HeliusSortOrder] (`"desc"`, `"asc"`).
+            API default: `"desc"` (newest first).
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    with_address: str | None = Field(default = None, alias = "with")
+    direction: str | None = None
+    mint: str | None = None
+    sol_mode: str | None = Field(default = None, alias = "solMode")
+    filters: PostGetTransfersByAddressFilters | None = None
+    limit: int | None = None
+    pagination_token: str | None = Field(default = None, alias = "paginationToken")
+    commitment: str | None = None
+    sort_order: str | None = Field(default = None, alias = "sortOrder")
+
+
+class Transfer(BaseModel):
+    """
+    A single parsed transfer record returned by the `getTransfersByAddress` RPC method.
+
+    Attributes:
+        signature: transaction signature this transfer belongs to.
+        slot: slot at which the transaction landed.
+        block_time: block timestamp in Unix seconds.
+        type: transfer behavior — one of `"transfer"`, `"mint"`, `"burn"`, `"wrap"`,
+            `"unwrap"`, `"changeOwner"`, `"withdrawWithheldFee"`.
+            See the Helius docs for the exact semantics of each value.
+        from_user_account: sender wallet (owner) address. `None` for `mint`, `wrap`
+            and `withdrawWithheldFee` rows, where the row has no sender side.
+        to_user_account: recipient wallet (owner) address. `None` for `burn` and
+            certain `unwrap` rows, where the row has no recipient side.
+        from_token_account: source SPL token account address. `None` for native SOL
+            transfers or rows where a source token account is not meaningful.
+        to_token_account: destination SPL token account address. `None` for native SOL
+            transfers or rows where a destination token account is not meaningful.
+        mint: token mint address for the transfer. In `solMode: "merged"`, WSOL
+            transfers are rewritten to the native SOL mint.
+        amount: raw transfer amount as a string (token base units). For Token-2022
+            transfers with fees, this is the amount credited to the destination.
+        decimals: number of decimal places for the mint.
+        ui_amount: human-readable amount (already scaled by `decimals`), returned as a string.
+        fee_amount: raw Token-2022 withheld fee as a string. `None` when the transfer
+            is not a Token-2022 `TransferCheckedWithFee` (i.e. no fees applied).
+        fee_ui_amount: human-readable Token-2022 withheld fee, returned as a string.
+            `None` when no fee applies.
+        confirmation_status: commitment level at the time of the response —
+            `"finalized"` or `"confirmed"`.
+        transaction_idx: index of the transaction within its block.
+        instruction_idx: index of the originating top-level instruction within the transaction.
+        inner_instruction_idx: index of the inner instruction (CPI) within its parent
+            top-level instruction.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    signature: str
+    slot: int
+    block_time: int = Field(alias = "blockTime")
+    type: str
+    from_user_account: str | None = Field(default = None, alias = "fromUserAccount")
+    to_user_account: str | None = Field(default = None, alias = "toUserAccount")
+    from_token_account: str | None = Field(default = None, alias = "fromTokenAccount")
+    to_token_account: str | None = Field(default = None, alias = "toTokenAccount")
+    mint: str
+    amount: str
+    decimals: int
+    ui_amount: str = Field(alias = "uiAmount")
+    fee_amount: str | None = Field(default = None, alias = "feeAmount")
+    fee_ui_amount: str | None = Field(default = None, alias = "feeUiAmount")
+    confirmation_status: str = Field(alias = "confirmationStatus")
+    transaction_idx: int = Field(alias = "transactionIdx")
+    instruction_idx: int = Field(alias = "instructionIdx")
+    inner_instruction_idx: int = Field(alias = "innerInstructionIdx")
+
+
+class TransferList(BaseModel):
+    """
+    Paginated list of parsed transfer rows returned inside the
+    `getTransfersByAddress` JSON-RPC result.
+
+    Attributes:
+        data: list of transfer rows for the current page, ordered as requested by
+            `sort_order`.
+        pagination_token: cursor to retrieve the next page, or `None` when no
+            further pages remain.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    data: list[Transfer]
+    pagination_token: str | None = Field(default = None, alias = "paginationToken")
+
+
 # ─── Response schemas (JSON-RPC 2.0 wrapper) ────────────────────────────────────
 
 class PostGetAssetResponse(BaseModel):
@@ -511,3 +695,157 @@ class PostGetTokenAccountsResponse(BaseModel):
     jsonrpc: str
     id: str | int
     result: TokenAccountList
+
+
+class PostGetTransfersByAddressResponse(BaseModel):
+    """JSON-RPC 2.0 response for the `getTransfersByAddress` RPC method."""
+    jsonrpc: str
+    id: str | int
+    result: TransferList
+
+
+# ─── getTransactionsForAddress schemas ─────────────────────────────────────────
+
+class PostGetTransactionsForAddressFilters(BaseModel):
+    """
+    Optional filters for the `getTransactionsForAddress` RPC method.
+
+    Attributes:
+        slot: filter by slot number using numeric comparison operators. `None` if not used.
+        block_time: filter by block timestamp in Unix seconds. `None` if not used.
+            This filter additionally accepts the `eq` operator on
+            [`HeliusComparisonFilter`][cyhole.helius.schema.HeliusComparisonFilter] for exact matches.
+        signature: filter by transaction signature with lexicographic comparison. `None` if not used.
+        status: filter by transaction success/failure. Accepts the values of
+            [`HeliusTransactionStatus`][cyhole.helius.param.HeliusTransactionStatus]
+            (`"succeeded"`, `"failed"`, `"any"`). `None` means no status filter (defaults to `"any"`).
+        token_accounts: include transactions for token accounts owned by the
+            queried address. Accepts the values of
+            [`HeliusTokenAccountFilter`][cyhole.helius.param.HeliusTokenAccountFilter]
+            (`"none"`, `"balanceChanged"`, `"all"`). API default: `"none"`.
+            Not supported for transactions older than December 2022.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    slot: HeliusComparisonFilter | None = None
+    block_time: HeliusComparisonFilter | None = Field(default = None, alias = "blockTime")
+    signature: HeliusSignatureComparisonFilter | None = None
+    status: str | None = None
+    token_accounts: str | None = Field(default = None, alias = "tokenAccounts")
+
+
+class PostGetTransactionsForAddressBody(BaseModel):
+    """
+    Request body (the `config` object) for the `getTransactionsForAddress` RPC method.
+
+    The queried `address` is passed as the first positional parameter of the JSON-RPC
+    call and is therefore handled separately by the
+    [`Helius._post_get_transactions_for_address`][cyhole.helius.interaction.Helius._post_get_transactions_for_address]
+    method; every field of this body model is optional.
+
+    Attributes:
+        transaction_details: level of detail returned for each transaction. Accepts the
+            values of [`HeliusTransactionDetails`][cyhole.helius.param.HeliusTransactionDetails]
+            (`"signatures"`, `"full"`). API default: `"signatures"`. Use `"full"` to obtain
+            the complete transaction payload in a single call (`limit` must be `<= 100`).
+        sort_order: result ordering. Accepts the values of
+            [`HeliusSortOrder`][cyhole.helius.param.HeliusSortOrder] (`"desc"`, `"asc"`).
+            API default: `"desc"` (newest first).
+        limit: maximum number of transactions returned. Up to `1000` in `"signatures"`
+            mode and up to `100` in `"full"` mode. API default: `1000`.
+        pagination_token: cursor from the previous response — pass the value received
+            in `result.pagination_token` (format `"slot:position"`) to fetch the next page.
+        commitment: data commitment level. Accepts the values of
+            [`HeliusCommitment`][cyhole.helius.param.HeliusCommitment] (`"finalized"`,
+            `"confirmed"`). API default: `"finalized"` (`"processed"` is **not** supported).
+        filters: advanced filters — see
+            [`PostGetTransactionsForAddressFilters`][cyhole.helius.schema.PostGetTransactionsForAddressFilters].
+        encoding: encoding format for the transaction payload — only meaningful when
+            `transaction_details = "full"`. Accepts the values of
+            [`HeliusEncoding`][cyhole.helius.param.HeliusEncoding]
+            (`"json"`, `"jsonParsed"`, `"base64"`, `"base58"`).
+        max_supported_transaction_version: maximum transaction version to return.
+            When `None`, the API only returns legacy transactions; set to `0` to include
+            all versioned transactions.
+        min_context_slot: minimum slot at which the request may be evaluated.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    transaction_details: str | None = Field(default = None, alias = "transactionDetails")
+    sort_order: str | None = Field(default = None, alias = "sortOrder")
+    limit: int | None = None
+    pagination_token: str | None = Field(default = None, alias = "paginationToken")
+    commitment: str | None = None
+    filters: PostGetTransactionsForAddressFilters | None = None
+    encoding: str | None = None
+    max_supported_transaction_version: int | None = Field(default = None, alias = "maxSupportedTransactionVersion")
+    min_context_slot: int | None = Field(default = None, alias = "minContextSlot")
+
+
+class TransactionForAddressItem(BaseModel):
+    """
+    A single transaction record returned by `getTransactionsForAddress`.
+
+    Fields populated depend on the `transaction_details` mode requested:
+
+    * `"signatures"` mode (API default) populates `signature`, `err`, `memo`, and `confirmation_status`.
+    * `"full"` mode populates `transaction` and `meta` instead.
+
+    Fields outside the active mode are `None`.
+
+    Attributes:
+        slot: slot containing the block with this transaction. Always present.
+        transaction_index: zero-based index of the transaction within its block.
+            Always present; unique to `getTransactionsForAddress` (not exposed by
+            `getSignaturesForAddress` / `getTransaction`).
+        block_time: estimated production time as a Unix timestamp (seconds).
+            `None` when the block time cannot be determined.
+        signature: base58-encoded transaction signature. Populated only in `"signatures"` mode.
+        err: transaction error object, or `None` if the transaction succeeded.
+            Populated only in `"signatures"` mode.
+        memo: memo attached to the transaction, or `None` if no memo. Populated only
+            in `"signatures"` mode.
+        confirmation_status: cluster confirmation status (`"finalized"`, `"confirmed"`).
+            Populated only in `"signatures"` mode.
+        transaction: full transaction payload (message, signatures, instructions) in the
+            shape returned by Solana's `getTransaction` RPC method. Populated only in
+            `"full"` mode. Encoding follows the body's `encoding` parameter.
+        meta: transaction metadata (fee, pre/post balances, inner instructions, log
+            messages, etc.) in the shape returned by Solana's `getTransaction` RPC
+            method. Populated only in `"full"` mode.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    slot: int
+    transaction_index: int = Field(alias = "transactionIndex")
+    block_time: int | None = Field(default = None, alias = "blockTime")
+    signature: str | None = None
+    err: dict | None = None
+    memo: str | None = None
+    confirmation_status: str | None = Field(default = None, alias = "confirmationStatus")
+    transaction: dict | None = None
+    meta: dict | None = None
+
+
+class TransactionForAddressList(BaseModel):
+    """
+    Paginated list of transactions returned inside the `getTransactionsForAddress`
+    JSON-RPC result.
+
+    Attributes:
+        data: list of transaction items for the current page, ordered as requested
+            by `sort_order`.
+        pagination_token: cursor (format `"slot:position"`) to retrieve the next page,
+            or `None` when no further pages remain.
+    """
+    model_config = ConfigDict(populate_by_name = True)
+
+    data: list[TransactionForAddressItem]
+    pagination_token: str | None = Field(default = None, alias = "paginationToken")
+
+
+class PostGetTransactionsForAddressResponse(BaseModel):
+    """JSON-RPC 2.0 response for the `getTransactionsForAddress` RPC method."""
+    jsonrpc: str
+    id: str | int
+    result: TransactionForAddressList

--- a/tests/resources/mock/helius/postGetTransactionsForAddress_default.json
+++ b/tests/resources/mock/helius/postGetTransactionsForAddress_default.json
@@ -1,0 +1,18 @@
+{
+    "jsonrpc": "2.0",
+    "id": "cyhole",
+    "result": {
+        "data": [
+            {
+                "signature": "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
+                "slot": 1054,
+                "transactionIndex": 42,
+                "err": null,
+                "memo": null,
+                "blockTime": 1641038400,
+                "confirmationStatus": "finalized"
+            }
+        ],
+        "paginationToken": "1055:5"
+    }
+}

--- a/tests/resources/mock/helius/postGetTransfersByAddress_default.json
+++ b/tests/resources/mock/helius/postGetTransfersByAddress_default.json
@@ -1,0 +1,29 @@
+{
+    "jsonrpc": "2.0",
+    "id": "cyhole",
+    "result": {
+        "data": [
+            {
+                "signature": "5GEX7Q3X5Q8yJGbKYoR7mtzQmG8tpoEwzjPgqVmn3y5xg3yKwqXcDdN5YVcc9V6vA4TuH5iM6FHRVhTxvz4AX2zG",
+                "slot": 315073428,
+                "blockTime": 1736159420,
+                "type": "transfer",
+                "fromUserAccount": "7hPhaUpydpvm8wtiS3k4LPZKUmivQRs7YQmpE1hFshHx",
+                "toUserAccount": "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY",
+                "fromTokenAccount": "HcvK3EJ74iM9g11cUgsaPvLSrhCvCwcrWxBNd87LsC1x",
+                "toTokenAccount": "CBcYniR9G9CN3zGMnwNE4SWbqkYWvCFVreEob9xHnQCY",
+                "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "amount": "2500000",
+                "decimals": 6,
+                "uiAmount": "2.5",
+                "feeAmount": null,
+                "feeUiAmount": null,
+                "confirmationStatus": "finalized",
+                "transactionIdx": 35,
+                "instructionIdx": 1,
+                "innerInstructionIdx": 0
+            }
+        ],
+        "paginationToken": "315073428:35:1:0:splTransfer"
+    }
+}

--- a/tests/test_helius.py
+++ b/tests/test_helius.py
@@ -10,6 +10,8 @@ from cyhole.helius.schema import (
     PostGetAssetsByAuthorityBody,
     PostSearchAssetsBody,
     PostGetTokenAccountsBody,
+    PostGetTransfersByAddressBody,
+    PostGetTransactionsForAddressBody,
     PostGetAssetResponse,
     PostGetAssetBatchResponse,
     PostGetAssetProofResponse,
@@ -22,6 +24,8 @@ from cyhole.helius.schema import (
     PostGetSignaturesForAssetResponse,
     PostGetNftEditionsResponse,
     PostGetTokenAccountsResponse,
+    PostGetTransfersByAddressResponse,
+    PostGetTransactionsForAddressResponse,
 )
 from .config import load_config, MockerManager
 
@@ -38,6 +42,7 @@ TEST_CREATOR_ADDRESS = "CREAT1111111111111111111111111111111111111111"
 TEST_AUTHORITY_ADDRESS = "AUTH1111111111111111111111111111111111111111"
 TEST_MASTER_MINT = "MASTER11111111111111111111111111111111111111"
 TEST_TOKEN_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+TEST_TRANSFER_ADDRESS = "86xCnPeV69n6t3DnyGvkKobf9FdN2H9oiVDdaMpo2MMY"
 
 
 class TestHelius:
@@ -505,3 +510,79 @@ class TestHelius:
             response = await client.post_get_token_accounts(body)
         assert isinstance(response, PostGetTokenAccountsResponse)
         assert response.result.total > 0
+
+    # ─── getTransfersByAddress ────────────────────────────────────────────────
+
+    def test_post_get_transfers_by_address_sync(self, mocker: MockerFixture) -> None:
+        """
+        Unit Test for endpoint "getTransfersByAddress" — synchronous logic.
+
+        Mock Response File: postGetTransfersByAddress_default.json
+        """
+        mock_file_name = "postGetTransfersByAddress_default"
+        if config.mock_response or config.helius.mock_response:
+            mock_response = self.mocker.load_mock_response(mock_file_name, PostGetTransfersByAddressResponse)
+            mocker.patch("cyhole.core.client.APIClient.api", return_value = mock_response)
+
+        response = self.helius.client.post_get_transfers_by_address(TEST_TRANSFER_ADDRESS)
+        assert isinstance(response, PostGetTransfersByAddressResponse)
+        assert len(response.result.data) > 0
+
+        if config.mock_file_overwrite and not config.helius.mock_response:
+            self.mocker.store_mock_model(mock_file_name, response)
+
+    @pytest.mark.asyncio
+    async def test_post_get_transfers_by_address_async(self, mocker: MockerFixture) -> None:
+        """
+        Unit Test for endpoint "getTransfersByAddress" — asynchronous logic.
+
+        Mock Response File: postGetTransfersByAddress_default.json
+        """
+        mock_file_name = "postGetTransfersByAddress_default"
+        if config.mock_response or config.helius.mock_response:
+            mock_response = self.mocker.load_mock_response(mock_file_name, PostGetTransfersByAddressResponse)
+            mocker.patch("cyhole.core.client.AsyncAPIClient.api", return_value = mock_response)
+
+        body = PostGetTransfersByAddressBody(limit = 50)
+        async with self.helius.async_client as client:
+            response = await client.post_get_transfers_by_address(TEST_TRANSFER_ADDRESS, body)
+        assert isinstance(response, PostGetTransfersByAddressResponse)
+        assert len(response.result.data) > 0
+
+    # ─── getTransactionsForAddress ────────────────────────────────────────────
+
+    def test_post_get_transactions_for_address_sync(self, mocker: MockerFixture) -> None:
+        """
+        Unit Test for endpoint "getTransactionsForAddress" — synchronous logic.
+
+        Mock Response File: postGetTransactionsForAddress_default.json
+        """
+        mock_file_name = "postGetTransactionsForAddress_default"
+        if config.mock_response or config.helius.mock_response:
+            mock_response = self.mocker.load_mock_response(mock_file_name, PostGetTransactionsForAddressResponse)
+            mocker.patch("cyhole.core.client.APIClient.api", return_value = mock_response)
+
+        response = self.helius.client.post_get_transactions_for_address(TEST_TRANSFER_ADDRESS)
+        assert isinstance(response, PostGetTransactionsForAddressResponse)
+        assert len(response.result.data) > 0
+
+        if config.mock_file_overwrite and not config.helius.mock_response:
+            self.mocker.store_mock_model(mock_file_name, response)
+
+    @pytest.mark.asyncio
+    async def test_post_get_transactions_for_address_async(self, mocker: MockerFixture) -> None:
+        """
+        Unit Test for endpoint "getTransactionsForAddress" — asynchronous logic.
+
+        Mock Response File: postGetTransactionsForAddress_default.json
+        """
+        mock_file_name = "postGetTransactionsForAddress_default"
+        if config.mock_response or config.helius.mock_response:
+            mock_response = self.mocker.load_mock_response(mock_file_name, PostGetTransactionsForAddressResponse)
+            mocker.patch("cyhole.core.client.AsyncAPIClient.api", return_value = mock_response)
+
+        body = PostGetTransactionsForAddressBody(limit = 50)
+        async with self.helius.async_client as client:
+            response = await client.post_get_transactions_for_address(TEST_TRANSFER_ADDRESS, body)
+        assert isinstance(response, PostGetTransactionsForAddressResponse)
+        assert len(response.result.data) > 0


### PR DESCRIPTION
## Summary

Extend the `Helius` interaction with two endpoints from the parsed-history RPC surface:

- **`getTransfersByAddress`** — parsed token and native SOL transfer rows for a wallet, with `mint`, `blockTime`, `slot`, `amount`, direction and counterparty filters, plus SOL/WSOL `merged`/`separate` modes and cursor pagination.
- **`getTransactionsForAddress`** — dual-mode (`signatures` / `full`) transaction history with status, time, slot, signature, and token-account filters, bidirectional sorting, and pagination. Models both response shapes on a single `TransactionForAddressItem` with mode-specific optional fields.

### Schemas (`schema.py`)
- `HeliusComparisonFilter` extended with optional `eq` (honored only for `blockTime` in `getTransactionsForAddress` per the docs)
- `HeliusSignatureComparisonFilter` for the lexicographic signature filter
- `PostGetTransfersByAddressBody` / `PostGetTransfersByAddressFilters` / `Transfer` / `TransferList` / `PostGetTransfersByAddressResponse`
- `PostGetTransactionsForAddressBody` / `PostGetTransactionsForAddressFilters` / `TransactionForAddressItem` / `TransactionForAddressList` / `PostGetTransactionsForAddressResponse`

### Param enums (`param.py`)
- `HeliusTransferDirection`, `HeliusSolMode`, `HeliusCommitment`, `HeliusSortOrder` — shared by both endpoints
- `HeliusTransactionDetails`, `HeliusTransactionStatus`, `HeliusTokenAccountFilter`, `HeliusEncoding` — `getTransactionsForAddress`

### Interaction + clients
- `_post_get_transfers_by_address` and `_post_get_transactions_for_address` private methods with the standard two-`@overload` pattern
- Sync + async `post_*` methods on `HeliusClient` / `HeliusAsyncClient`
- Functional docstrings cover Helius-exclusive nature, credit cost (10 / 50), retention limits, and the pre-Dec-2022 `tokenAccounts` caveat

### Tests + docs
- Mock fixtures `postGetTransfersByAddress_default.json` and `postGetTransactionsForAddress_default.json` (signatures-mode)
- Sync + async test pairs added for both endpoints (28 total Helius tests)
- Both endpoints registered in `docs/interactions/helius/index.md` under release `0.3.0`

## Test plan

- [x] `ruff check src/` — clean
- [x] `pytest tests/test_helius.py -v` — 28/28 passed (incl. 4 new sync/async tests)
- [x] `mkdocs build --strict` — zero WARNINGs, zero ERRORs